### PR TITLE
Change parse mode to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Copy
 Edit
 for post in load_posts_from_json():
     await bot.send_media_group(chat_id, [InputMedia(…)] if media else None)
-    await bot.send_message(chat_id, post["text"], parse_mode="Markdown")
+    await bot.send_message(chat_id, post["text"], parse_mode="HTML")
     await asyncio.sleep(DELAY_BETWEEN_POSTS)  # 10 сек
 Использовать send_photo, send_animation или send_video в зависимости от расширения файла (.jpg → photo, .gif → animation, .mov → video).
 

--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,7 @@ async def start(message: types.Message):
         f"{user.first_name}, лови статью «Чек‑ап женского здоровья: как не пропустить "
         f"важное и сохранить молодость?»\n\n{GOOGLE_DRIVE_URL}"
     )
-    await message.answer(greeting)
+    await message.answer(greeting, parse_mode="HTML")
     await send_posts(message.chat.id)
     subscribed = await check_subscription(user.id)
     if not subscribed:
@@ -60,7 +60,7 @@ async def start(message: types.Message):
             url=f'https://t.me/{CHANNEL_USERNAME.lstrip("@")}'
         )
         markup = InlineKeyboardMarkup().add(button)
-        await message.answer('Подпишись на канал, чтобы не пропустить важное!', reply_markup=markup)
+        await message.answer('Подпишись на канал, чтобы не пропустить важное!', reply_markup=markup, parse_mode="HTML")
     update_subscription(LOG_FILE, user.id, 'yes' if subscribed else 'no')
 
 


### PR DESCRIPTION
## Summary
- default to HTML when sending posts and other messages
- document HTML parse mode in readme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4ef2ef048321ba5f58c20d05cd6c