### PR TITLE
Switch to Markdown parsing outside posts

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,7 @@ async def start(message: types.Message):
         f"{user.first_name}, лови статью «Чек‑ап женского здоровья: как не пропустить "
         f"важное и сохранить молодость?»\n\n{GOOGLE_DRIVE_URL}"
     )
-    await message.answer(greeting, parse_mode="HTML")
+    await message.answer(greeting, parse_mode="Markdown")
     await send_posts(message.chat.id)
     subscribed = await check_subscription(user.id)
     if not subscribed:
@@ -60,7 +60,7 @@ async def start(message: types.Message):
             url=f'https://t.me/{CHANNEL_USERNAME.lstrip("@")}'
         )
         markup = InlineKeyboardMarkup().add(button)
-        await message.answer('Подпишись на канал, чтобы не пропустить важное!', reply_markup=markup, parse_mode="HTML")
+        await message.answer('Подпишись на канал, чтобы не пропустить важное!', reply_markup=markup, parse_mode="Markdown")
     update_subscription(LOG_FILE, user.id, 'yes' if subscribed else 'no')
 
 


### PR DESCRIPTION
## Summary
- use Markdown for greeting and subscription messages
- keep HTML for post loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e008cf5e08321a0c5689949d676fb